### PR TITLE
Add settings and template for 20auto-upgrades, fixes #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ TODO: Third party PPA's are not yet supported in the allowed origins section
 * `['unattended-upgrades']['remove_unused_dependencies']`
 * `['unattended-upgrades']['automatic_reboot']`
 * `['unattended-upgrades']['download_limit']`
+* `['unattended_upgrades']['update_package_lists_interval']
+* `['unattended_upgrades']['upgrade_interval']
+* `['unattended_upgrades']['download_upgradeable_interval']
+* `['unattended_upgrades']['autoclean_interval']
 
 # Recipes
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,3 +16,9 @@ default['unattended-upgrades']['allowed_origins'] = {
 }
 
 default['unattended-upgrades']['apt_recipe'] = 'default'
+
+# interval settings in days
+default['unattended-upgrades']['update_package_lists_interval'] = 1
+default['unattended-upgrades']['upgrade_interval'] = 1 # In order for unattended upgrades to run at all, this must be set to an integer greater than or equal to 1
+default['unattended-upgrades']['download_upgradeable_interval'] = nil
+default['unattended-upgrades']['autoclean_interval'] = nil

--- a/files/default/tests/minitest/default_test.rb
+++ b/files/default/tests/minitest/default_test.rb
@@ -15,15 +15,19 @@ describe_recipe 'unattended-upgrades::default' do
 
   describe 'files' do
     let(:config) { file("/etc/apt/apt.conf.d/50unattended-upgrades") }
+    let(:autoconfig) { file("/etc/apt/apt.conf.d/20auto-upgrades") }
 
     it 'should have correct file permissions' do
       config.must_have(:mode, "644")
+      autoconfig.must_have(:mode, "644")
     end
     it 'should have correct owner' do
       config.must_have(:owner, "root")
+      autoconfig.must_have(:owner, "root")
     end
     it 'should have correct group' do
       config.must_have(:group, "root")
+      autoconfig.must_have(:group, "root")
     end
 
     it 'should contain the correct config' do
@@ -33,6 +37,11 @@ describe_recipe 'unattended-upgrades::default' do
     it 'should contain the security updates origin' do
       # Although this test may fail on a setup with minitest-handler running on a live server - security updates really shouldn't be turned off
       config.must_include '"${distro_id}:${distro_codename}-security";'
+    end
+
+    it 'should run unattended upgrades according to the schedule' do
+      # Test might fail if unattended upgrades is disabled via run interval setting - but why run this test if the software is turned off?
+      autoconfig.must_include "APT::Periodic::Unattended-Upgrade \"#{node['unattended-upgrades']['upgrade_interval']}\";"
     end
   end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -44,3 +44,16 @@ template '/etc/apt/apt.conf.d/50unattended-upgrades' do
     :download_limit             => node['unattended-upgrades']['download_limit']
   )
 end
+
+template '/etc/apt/apt.conf.d/20auto-upgrades' do
+  source 'auto-upgrades.conf.erb'
+  owner 'root'
+  group 'root'
+  mode  '0644'
+  variables(
+    :update_package_lists_interval => node['unattended-upgrades']['update_package_lists_interval'],
+    :upgrade_interval              => node['unattended-upgrades']['upgrade_interval'],
+    :download_upgradeable_interval => node['unattended-upgrades']['download_upgradeable_interval'],
+    :autoclean_interval            => node['unattended-upgrades']['autoclean_interval'],
+  )
+end

--- a/templates/default/auto-upgrades.conf.erb
+++ b/templates/default/auto-upgrades.conf.erb
@@ -1,0 +1,4 @@
+<% if @update_package_lists_interval -%>APT::Periodic::Update-Package-Lists "<%= @update_package_lists_interval %>";<% end -%>
+<% if @upgrade_interval -%>APT::Periodic::Unattended-Upgrade "<%= @upgrade_interval %>";<% end -%>
+<% if @download_upgradeable_interval -%>APT::Periodic::Download-Upgradeable-Packages "<%= @download_upgradeable_interval %>";<% end -%>
+<% if @autoclean_interval -%>APT::Periodic::AutocleanInterval "<%= @autoclean_interval%>";<% end -%>


### PR DESCRIPTION
As noted in the issue #7 , unattended upgrades needs to have at least the unattended-upgrade interval set, presumably to something >= 1 (day).  This commit provides that setting, the apt-get update interval setting, and also allows the other settings usually included in that file to be set by attributes.
