### PR TITLE
Support Debian

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,12 +8,21 @@ default['unattended-upgrades']['remove_unused_dependencies'] = false
 default['unattended-upgrades']['automatic_reboot']           = false
 default['unattended-upgrades']['download_limit']             = nil   # Set to Integer representing kb/sec limit
 
-default['unattended-upgrades']['allowed_origins'] = {
-  'security'  => true,
-  'updates'   => false,
-  'proposed'  => false,
-  'backports' => false
-}
+case node['platform']
+when 'ubuntu'
+  default['unattended-upgrades']['allowed_origins'] = {
+    'security'  => true,
+    'updates'   => false,
+    'proposed'  => false,
+    'backports' => false
+  }
+  default['unattended-upgrades']['origin_patterns'] = {}
+when 'debian'
+  default['unattended-upgrades']['allowed_origins'] = {}
+  default['unattended-upgrades']['origin_patterns'] = {
+    'origin=Debian,archive=stable,label=Debian-Security' => true
+  }
+end
 
 default['unattended-upgrades']['apt_recipe'] = 'default'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,9 +4,9 @@ maintainer_email "jeremy.olliver@gmail.com"
 license          "Apache 2.0"
 description      "Installs/Configures unattended-upgrades"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.2"
+version          "0.2.0"
 
-# supports "debian" # Untested
+supports "debian"
 supports "ubuntu"
 
 depends "apt"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -37,6 +37,7 @@ template '/etc/apt/apt.conf.d/50unattended-upgrades' do
   mode  '0644'
   variables(
     :allowed_origins            => node['unattended-upgrades']['allowed_origins'],
+    :origin_patterns            => node['unattended-upgrades']['origin_patterns'],
     :package_blacklist          => node['unattended-upgrades']['package_blacklist'],
     :autofix_dpkg               => node['unattended-upgrades']['autofix_dpkg'],
     :minimal_steps              => node['unattended-upgrades']['minimal_steps'],

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -16,8 +16,16 @@ describe 'unattended-upgrades::default' do
       end
 
       it 'should write the config files' do
-        expect(chef_run).to render_file('/etc/apt/apt.conf.d/50unattended-upgrades').with_content('Unattended-Upgrade::Mail "root@localhost"')
-        expect(chef_run).to render_file('/etc/apt/apt.conf.d/20auto-upgrades').with_content('APT::Periodic::Unattended-Upgrade "1"')
+        expect(chef_run).to render_file('/etc/apt/apt.conf.d/50unattended-upgrades')
+          .with_content('Unattended-Upgrade::Mail "root@localhost"')
+        expect(chef_run).to render_file('/etc/apt/apt.conf.d/50unattended-upgrades')
+          .with_content('Unattended-Upgrade::Allowed-Origins')
+        expect(chef_run).to_not render_file('/etc/apt/apt.conf.d/50unattended-upgrades')
+          .with_content('Unattended-Upgrade::Origins-Pattern')
+        expect(chef_run).to render_file('/etc/apt/apt.conf.d/50unattended-upgrades')
+          .with_content('"${distro_id}:${distro_codename}-security"')
+        expect(chef_run).to render_file('/etc/apt/apt.conf.d/20auto-upgrades')
+          .with_content('APT::Periodic::Unattended-Upgrade "1"')
       end
 
       it 'should not warn about missing mail package' do
@@ -41,8 +49,16 @@ describe 'unattended-upgrades::default' do
     end
 
     it 'should write the config files' do
-      expect(chef_run).to render_file('/etc/apt/apt.conf.d/50unattended-upgrades').with_content('Unattended-Upgrade::Mail')
-      expect(chef_run).to render_file('/etc/apt/apt.conf.d/20auto-upgrades').with_content('APT::Periodic::Unattended-Upgrade "1"')
+      expect(chef_run).to render_file('/etc/apt/apt.conf.d/50unattended-upgrades').
+        with_content('Unattended-Upgrade::Mail')
+      expect(chef_run).to_not render_file('/etc/apt/apt.conf.d/50unattended-upgrades')
+        .with_content('Unattended-Upgrade::Allowed-Origins')
+      expect(chef_run).to render_file('/etc/apt/apt.conf.d/50unattended-upgrades')
+        .with_content('Unattended-Upgrade::Origins-Pattern')
+      expect(chef_run).to render_file('/etc/apt/apt.conf.d/50unattended-upgrades')
+        .with_content('origin=Debian,archive=stable,label=Debian-Security')
+      expect(chef_run).to render_file('/etc/apt/apt.conf.d/20auto-upgrades')
+        .with_content('APT::Periodic::Unattended-Upgrade "1"')
     end
   end
 

--- a/templates/default/unattended-upgrades.conf.erb
+++ b/templates/default/unattended-upgrades.conf.erb
@@ -1,11 +1,24 @@
 // File configured by chef - don't edit manually
 
+<% unless @allowed_origins.empty? %>
 // Automatically upgrade packages from these (origin:archive) pairs
 Unattended-Upgrade::Allowed-Origins {
 <% @allowed_origins.each do |origin, enabled| %>
-<%= '//' unless enabled %>  "${distro_id}:${distro_codename}-<%= origin %>";
+  <%= "\"${distro_id}:${distro_codename}-#{origin}\";" if enabled -%>
 <% end %>
+
 };
+<% end %>
+
+<% unless @origin_patterns.empty? %>
+// Automatically upgrade packages from these origin patterns
+Unattended-Upgrade::Origins-Pattern {
+<% @origin_patterns.each do |pattern, enabled| %>
+  <%= "\"#{pattern}\";" if enabled -%>
+<% end %>
+
+};
+<% end %>
 
 // List of packages to not update
 Unattended-Upgrade::Package-Blacklist {


### PR DESCRIPTION
I had to use `Unattended-Upgrade::Allowed-Origins` on Debian because security updates have a "Debian-Security" label.

I've bumped the version number (minor, since it's adding an attribute) and uncommented the support 'debian' line in a separate commit so you can cherry-pick if you want.

I've added some specs for it. We've been running this version of the cookbook in production since yesterday
